### PR TITLE
Manager Executor: don't inc next gen repetitively & try rescale to 0 on rescale error

### DIFF
--- a/src/services/manager/executor/executor.go
+++ b/src/services/manager/executor/executor.go
@@ -147,9 +147,12 @@ func (e *executor) RecalculateDS() (resp api.RecalculateDsResponse, code int, er
 	if err := e.rescaleAllRegions(ctx, 0); err != nil {
 		return wrap(err)
 	}
-	if err := e.incNextGen(ctx); err != nil {
-		return wrap(err) // TODO[wprzytula]: consider inc iff not yet incremented
+	if e.nextGeneration == e.generation { // We inc iff not yet inc'ed. Reason: save already done work.
+		if err := e.incNextGen(ctx); err != nil {
+			return wrap(err)
+		}
 	}
+
 	if err := e.divideIntoRegions(ctx); err != nil {
 		return wrap(err)
 	}


### PR DESCRIPTION
1. Inc next gen only if not yet inc'ed.
2. If rescaling fails on some regions, attempt rescaling on regions to 0 for coherence.

More details + explanations in commit messages & comments.